### PR TITLE
misc fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,14 @@
+# Makefile for libpfc userland and kernel components.
+# The preferred build method for libpfc is the combination of meson and ninja, and so this Makefile
+# may not always be up to date. It is provided for projects that prefer make-only builds.
+
 .PHONY : all clean
 
 vpath %.c src
 vpath %.h include
 
 CFLAGS += -Wall -Winvalid-pch -O0 -g -Iinclude -std=gnu99
-SHAREDLIB_FLAGS = -Wl,--no-undefined -Wl,--as-needed -shared -fPIC -Wl,-soname,libpfc.so '-Wl,-rpath,$$ORIGIN/' -Wl,-rpath-link,/home/tdowns/dev/uarch-bench/libpfc/build/src
+SHAREDLIB_FLAGS = -Wl,--no-undefined -Wl,--as-needed -shared -fPIC -Wl,-soname,libpfc.so '-Wl,-rpath,$$ORIGIN/'
 
 all : libpfc.so pfcdemo pfc.ko
 
@@ -20,7 +24,7 @@ pfcdemo.o : pfcdemo.c libpfc.h
 pfcdemo : pfcdemo.o libpfc.so
 	$(CC) '-Wl,-rpath,$$ORIGIN/' -L. pfcdemo.o -lpfc -lm -o pfcdemo
 
-pfc.ko: kmod/pfckmod.c kmod/Makefile
+pfc.ko : kmod/pfckmod.c kmod/Makefile
 	rm -rf kmod.build
 	cp -r kmod kmod.build
 	cd kmod.build && $(MAKE) MAKEFLAGS=

--- a/include/libpfc.h
+++ b/include/libpfc.h
@@ -20,6 +20,19 @@ typedef int64_t   PFC_CNT;
 #define PFC_FIXEDCNT_CPU_CLK_UNHALTED     1      /* CPU_CLK_UNHALTED.THREAD */
 #define PFC_FIXEDCNT_CPU_CLK_REF_TSC      2      /* CPU_CLK_UNHALTED.REF_TSC */
 
+/* Error Codes
+ *
+ * Functions that return an int error may return one of the following codes, which can be turned
+ * into a human-readable string using pfcErrorString.
+ */
+#define PFC_ERR_OPENING_SYSFILE (-10) // couldn't open the /sys/modules/pfc files, kernel module probably not loaded
+#define PFC_ERR_PWRITE_FAILED   (-11) // a pwrite() call returned error (check errno?)
+#define PFC_ERR_PWRITE_TOO_FEW  (-12) // a pwrite() call wrote less than the expected number of bytes
+#define PFC_ERR_CPU_PIN_FAILED  (-13) // cpu pinning failed, probably in sched_setaffinity
+#define PFC_ERR_CR4_PCE_NOT_SET (-14) // drive reported that cr4.pce wasn't set, or there was somehow an issue reading it
+#define PFC_ERR_AFFINITY_FAILED (-15) // setting CPU affinity failed (perhaps affinity is set externally excluding CPU 0?)
+#define PFC_ERR_READING_MASKS   (-16) // didn't read the expected number of mask bytes from the sysfs
+
 
 /* Extern "C" Guard */
 #ifdef __cplusplus


### PR DESCRIPTION
- Move error codes to header
- Return right error code when mask read fails
- close() the `cr4.pce` file
- Add note to `Makefile` regarding it not being the preferred build method
- set `-std=gnu99` in `CFLAGS`
- remove local path in `rlink-path` 