### PR TITLE
add travis-ci integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,30 @@
+language: c
+sudo: required
+
+addons:
+  apt:
+    sources:
+      - deadsnakes
+    packages:
+      - linux-headers-4.4.0-101-generic
+      - python3.6
+      - python3.6-dev
+      
+matrix:
+  include:
+    - env: BUILD=MAKE
+      script:
+      - make
+    - env: BUILD=meson
+      install:
+        - mkdir build
+        - export PATH="`pwd`/build:${PATH}"
+        - wget https://github.com/ninja-build/ninja/releases/download/v1.7.2/ninja-linux.zip && unzip -q ninja-linux.zip -d build
+        - curl https://bootstrap.pypa.io/get-pip.py | sudo python3.6
+        - sudo python3.6 -m pip install meson
+        - meson --version
+      script:
+        - uname -r && cd build && meson .. -Dbuildtype=release --prefix=$HOME/.local
+        - ninja
+        - ninja install
+


### PR DESCRIPTION
This change adds Travis-CI integration, both for meson (which was an incredible struggle to get working on TravisCI since every single version of {python, meson, and ninja} were too old) and make.

You can see a typical build result here:

https://travis-ci.org/travisdowns/libpfc/builds/354614705

To get it running, you just need to sign up for Travis-CI (you can just click the "use my github account") and then enable the switch for the libpfc repo. The build will start on the next commit (or you can trigger one by hand). It will also build PRs which is really handy.