### PR TITLE
allow makefile to build against an arbitrary kernel version

### DIFF
--- a/kmod/Makefile
+++ b/kmod/Makefile
@@ -1,5 +1,15 @@
+# This variable specifies the kernel name/version string that we'll try to
+# build against: normally you never want to set this since just want to pick
+# up the current kernel version using uname -r. It's here to allow you to 
+# "cross compile" against a different kernel version which is useful on 
+# Travis-CI, for example, where the available linux-header versions don't 
+# match the actual kernel version
+ifndef PFC_KMOD_KERNEL_NAME
+PFC_KMOD_KERNEL_NAME = $(shell uname -r)
+endif
+
 all:
-	make -C /lib/modules/$(shell uname -r)/build M=$(PWD) modules
+	make -C /lib/modules/$(PFC_KMOD_KERNEL_NAME)/build M=$(PWD) modules
 
 clean:
-	make -C /lib/modules/$(shell uname -r)/build M=$(PWD) clean
+	make -C /lib/modules/$(PFC_KMOD_KERNEL_NAME)/build M=$(PWD) clean


### PR DESCRIPTION
This is a change I made to the makefile for the kernel module to allow you to build against an arbitrary kernel version. See the comment in the file for the detailed reason.

In the end I didn't need it since with `sudo: required` in the `.travis.yml` file you get a different type of VM that still uses the mainstream 4.4.0 kernel series and I could install the "correct" headers for it. This this is useful if you want to try compiling against different kernel versions etc.

As a note, installing `linux-headers-generic` on the Travis CI arch doesn't work: it installs headers for a 3.x kernel, so I needed to explicitly list the linux headers to pull down in the `.yml`. When the kernel version they use changes I guess that will have to be updated (or we can use this variable to just "lock" it at the current version since we aren't actually doing the `insmod` anyways).